### PR TITLE
Add new-a2a-agent and deploy-ch2 Claude Code skills

### DIFF
--- a/claude-skills/README.md
+++ b/claude-skills/README.md
@@ -9,15 +9,16 @@ A skill is a single `SKILL.md` file with YAML frontmatter (`name`, `description`
 | Skill | What it does |
 |---|---|
 | [`new-a2a-agent`](./new-a2a-agent/) | Scaffold a new A2A (Agent-to-Agent) Mule application from the `a2a-credit-scoring-agent` template — substitutes agent name, skills, MCP URL, and planner/reasoner prompts. |
+| [`deploy-ch2`](./deploy-ch2/) | Deploy a Mule application to CloudHub 2.0 — packages the project (or uses an Exchange asset), runs pre-flight checks, and deploys with configurable replicas/vCores. |
 
 ## Installing
 
 ```bash
-# Per-user (available in every project)
-cp -R claude-skills/new-a2a-agent ~/.claude/skills/
+# Per-user (available in every project) — install one or all
+cp -R claude-skills/new-a2a-agent claude-skills/deploy-ch2 ~/.claude/skills/
 
 # Or per-project
-mkdir -p .claude/skills && cp -R claude-skills/new-a2a-agent .claude/skills/
+mkdir -p .claude/skills && cp -R claude-skills/new-a2a-agent claude-skills/deploy-ch2 .claude/skills/
 ```
 
-Then in Claude Code: `/new-a2a-agent`.
+Then in Claude Code: `/new-a2a-agent`, `/deploy-ch2`.

--- a/claude-skills/README.md
+++ b/claude-skills/README.md
@@ -1,0 +1,23 @@
+# Claude Code skills
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills that pair with the example apps in this repo.
+
+A skill is a single `SKILL.md` file with YAML frontmatter (`name`, `description`) plus instructions. Drop the folder into `~/.claude/skills/` (or a project-local `.claude/skills/`) and Claude Code will pick it up — invoke with `/<name>`.
+
+## Available skills
+
+| Skill | What it does |
+|---|---|
+| [`new-a2a-agent`](./new-a2a-agent/) | Scaffold a new A2A (Agent-to-Agent) Mule application from the `a2a-credit-scoring-agent` template — substitutes agent name, skills, MCP URL, and planner/reasoner prompts. |
+
+## Installing
+
+```bash
+# Per-user (available in every project)
+cp -R claude-skills/new-a2a-agent ~/.claude/skills/
+
+# Or per-project
+mkdir -p .claude/skills && cp -R claude-skills/new-a2a-agent .claude/skills/
+```
+
+Then in Claude Code: `/new-a2a-agent`.

--- a/claude-skills/deploy-ch2/SKILL.md
+++ b/claude-skills/deploy-ch2/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: deploy-ch2
+description: Deploy a Mule application to CloudHub 2.0. Packages the project (or uses an Exchange asset), uploads to a target environment, and starts it with configurable replicas/vCores, secure mode, and performance optimization. Use when the user says "deploy to CloudHub 2.0", "deploy this app", "push to CH2", or after implementing an API and wanting to go live.
+---
+
+# Deploy to CloudHub 2.0
+
+Deploys a Mule application to CloudHub 2.0 using the `mcp__mulesoft__deploy_mule_application` tool. Supports deploying from a local project or a published Exchange asset.
+
+## Inputs needed
+- **Source** — either:
+  - Local project path (an absolute path to a Mule project root containing `pom.xml`), OR
+  - Exchange asset (`groupId`, `assetId` / `artifactId`, `version`)
+  - Default: most recently worked-on impl project.
+- **App name** — default `<artifactId>` (derived from project `pom.xml`). Confirm if unclear.
+- **Environment** — default **Sandbox**. Ask if unclear (other common: `DEV`, `QA`, `Production`).
+- **Runtime version** — from `pom.xml` `<app.runtime>`. Verify via MCP that it's still current; flag if stale.
+- **Replicas** — default `1`. Ask for more only if the user mentions HA or traffic.
+- **vCores per replica** — default `0.1`. Ask if the user mentions throughput, memory concerns, or specific sizing.
+- **High availability / secure / performance optimization** — default all `false`. Ask only if context suggests production.
+- **Properties** — cleartext and secure properties must already be set in `pom.xml` under `<cloudhub2Deployment>` or passed via Maven `-D` flags. Flag any `REPLACE_WITH_*` placeholders in `config.yaml` / `application.properties`.
+
+If critical info is missing, ask concisely with suggested defaults.
+
+## Pre-flight checks (do not skip)
+Run these before calling the deploy tool. If any fails, stop and report — do not deploy a broken app.
+
+1. **Project packages cleanly**
+   - Run `mvn -B -f <project>/pom.xml clean package -DskipTests` with `JAVA_HOME` pointing at a JDK 17 install (any distribution: Zulu, Temurin, Corretto, etc.).
+   - Must produce `target/<artifactId>-<version>-mule-application.jar`.
+2. **POM has `<cloudhub2Deployment>` configured** (not `<cloudHubDeployment>` or `<rtfDeployment>`). If missing, stop and instruct user to add it.
+3. **No cleartext secrets in `config.yaml` / `application.properties`** — warn if placeholder strings like `REPLACE_WITH_*`, `your-domain`, `example.com`, or obvious test tokens are present. Ask the user to confirm before proceeding.
+4. **Runtime version is current** — compare POM `<app.runtime>` against MCP-reported latest. If a major LTS has been released since, flag it as an upgrade opportunity (do not silently bump).
+5. **App name is unique in target environment** — call `mcp__mulesoft__list_applications` and warn if a same-named app already exists (deploy will redeploy/replace).
+
+## Confirmation checkpoint (do not skip)
+Before calling the deploy tool, show the user:
+- Source (local path or Exchange coords)
+- Target environment
+- App name
+- Runtime version
+- Replicas × vCores
+- High availability / secure / performance optimization flags
+- Any placeholder/secret warnings from pre-flight
+
+Get explicit confirmation. Deploys are visible to others in the org and costs vCore-hours — do not skip this checkpoint.
+
+## Deploy
+Call `mcp__mulesoft__deploy_mule_application` with the confirmed inputs.
+
+- **Local project deploy** — pass `projectPath`, `appName`, `environmentName`, `runtimeVersion`, `minimumReplicas`, optional flags.
+- **Exchange asset deploy** — pass `groupId`, `artifactId`, `version`, `appName`, `environmentName`, `runtimeVersion`, `minimumReplicas`, optional flags.
+
+## Post-deploy
+1. Call `mcp__mulesoft__list_applications` for the target environment to confirm the app shows `STARTED` / `RUNNING`.
+2. If the app has an HTTP listener, report the CH 2.0 public URL pattern: `https://<app-name>.<region>.cloudhub.io/` (exact region depends on the deployment target).
+3. If status is `DEPLOY_FAILED` or stuck, pull logs via `list_applications` with `includeLogs=true, logLevel=ERROR` and report the first error.
+
+## Report back
+- App name + environment
+- Status (from `list_applications`)
+- Public URL if applicable
+- Replicas × vCores deployed
+- Runtime version deployed
+- Any warnings from pre-flight that the user acknowledged
+- Next steps: smoke-test the public URL, set up monitoring/alerting if not already configured
+
+## Rules
+- **CloudHub 2.0 only** — never CH 1.0 or RTF. If the POM targets those, stop and offer migration.
+- **Java 17** for the local `mvn package` step — set `JAVA_HOME` explicitly (do not let the shell's default JDK win if it's a different version).
+- **Do not silently bump the runtime version** — flag upgrade opportunities but require explicit user opt-in.
+- **Warn before overwriting existing deployed apps** — same `appName` in the same env will redeploy.
+- **Never deploy with placeholder credentials** — pre-flight must catch and warn.
+- Default environment is **Sandbox** unless the user specifies otherwise; for `Production`, require explicit confirmation and recommend `highAvailability=true` + `minimumReplicas>=2`.
+
+## Example
+> Deploy jira-tickets-api-impl to Sandbox
+
+1. Pre-flight: package with JDK 17 → verify `<cloudhub2Deployment>` → scan `config.yaml` (flag any `ATATT*` token in cleartext → warn user) → check runtime 4.11.2 is current → check no existing `jira-tickets-api-impl` in Sandbox.
+2. Confirm with user: Sandbox / 1 replica / 0.1 vCores / runtime 4.11.2 / no HA.
+3. Call `mcp__mulesoft__deploy_mule_application` with `projectPath`, `appName="jira-tickets-api-impl"`, `environmentName="Sandbox"`, `minimumReplicas=1`, `runtimeVersion="4.11.2"`.
+4. Poll `list_applications` until `STARTED` or error.
+5. Report URL `https://jira-tickets-api-impl.<region>.cloudhub.io/api/tickets/...` and next steps.

--- a/claude-skills/new-a2a-agent/SKILL.md
+++ b/claude-skills/new-a2a-agent/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: new-a2a-agent
+description: Scaffold a new A2A (Agent-to-Agent) Mule application by copying the a2a-credit-scoring-agent template and substituting agent name, description, skills, MCP server URL, and planner/reasoner prompts. Produces a runnable plan-then-execute agent on the latest Mule runtime, CloudHub 2.0-ready. Use when the user says "create a new A2A agent", "scaffold an agent for X", or describes a Mule agent that needs A2A + MCP + LLM wiring.
+---
+
+# New A2A agent (scaffold from credit-scoring template)
+
+Creates a new Mule A2A agent by copying `~/projects/active/a2a-credit-scoring-agent/` and rewriting the parts that vary per agent. The template is a known-working **plan-then-execute** loop with Planner LLM + Reasoner LLM + MCP tool calling + A2A server/client.
+
+## Inputs needed
+
+Collect these up front. Suggest defaults; confirm before scaffolding.
+
+| Input | Default / suggestion |
+|---|---|
+| **Agent name** | kebab-case, suffix `-agent` (e.g. `loan-approval-agent`). Suggest one from the user's description if not given. |
+| **One-line description** | Goes into `agent-card.json` `description` and the README. |
+| **Skills** | One or more entries: `id`, `name` (snake_case), `description`, `tags[]`. At minimum one skill. Mirror the `Get_Credit_Score` shape. |
+| **MCP server URL** | Required. Goes into `mcp.host.url`. **Do not append `/mcp`** — the connector adds it. |
+| **Project path** | `~/projects/active/<agent-name>/` (per standing rules) |
+| **Mule runtime** | **Latest** — verify via `mcp__mulesoft__get_workspace_info` / Exchange. Ask LTS vs Edge if ambiguous. Default Java 17. |
+| **LLM** | Gemini 2.5 Flash via `ms-inference` (matches template). Ask if the user wants a different model. |
+| **Ports** | A2A server `8081`, A2A client `7081`, web `9081` (template defaults). Override only if the user has a port conflict. |
+| **Deployment target** | CloudHub 2.0 (per standing rules). Don't generate CH 1.0 or RTF. |
+
+If the user hasn't supplied skills or MCP URL, ask concisely. Don't invent skills.
+
+## Steps
+
+### 1. Confirm plan
+
+Before any file writes, show the user:
+- Agent name
+- Skills list (id / name / description / tags)
+- MCP server URL
+- Target Mule runtime version (verified, latest)
+- Project path
+
+Get explicit confirmation. **Don't skip this.**
+
+### 2. Copy the template
+
+```bash
+cp -R ~/projects/active/a2a-credit-scoring-agent ~/projects/active/<agent-name>
+cd ~/projects/active/<agent-name>
+rm -rf target .mule .vscode
+```
+
+Then delete files that shouldn't carry over:
+- `target/`, `.mule/`, `.vscode/launch.json` if present
+- `src/main/resources/keystore.jks` (only there for the credit-scoring demo)
+- `exchange-docs/` (regenerate if publishing to Exchange later)
+
+### 3. Substitute names & metadata
+
+**`pom.xml`**
+- `<artifactId>` → `<agent-name>`
+- `<name>` → `<agent-name>`
+- `<groupId>` — keep the user's BG groupId (look it up via `mcp__mulesoft__get_workspace_info` if unknown; fall back to whatever the credit-scoring template has only with explicit user OK)
+- `<app.runtime>` → latest stable runtime (verified)
+
+**`mule-artifact.json`**
+- `name` → `<agent-name>`
+- `minMuleVersion` → latest (matching `pom.xml`)
+- Keep `javaSpecificationVersions: ["17"]`
+
+**`src/main/resources/agent-card.json`**
+
+Rewrite entirely from inputs:
+```json
+{
+  "name": "<Display Name>",
+  "description": "<one-line description>",
+  "url": "http://localhost:8081/<agent-path>",
+  "version": "1.0.0",
+  "protocolVersion": "0.4.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    { "id": "1", "name": "<Skill_Name>", "description": "<...>", "tags": ["..."] }
+  ]
+}
+```
+
+`<agent-path>` = the agent name without the `-agent` suffix (e.g. `loan-approval-agent` → `/loan-approval-agent`). Match `agent.xml`'s `agentPath`.
+
+### 4. Substitute config.properties
+
+```properties
+mcp.host.url=<USER_MCP_URL>          # do NOT include trailing /mcp
+
+# NOTE: plaintext placeholder for first-deploy convenience. Replace before any non-demo use.
+llm.api.key=__REPLACE_ME__
+llm.model.name=gemini-2.5-flash
+
+agent.url=http://localhost:8081/<agent-path>
+
+# Inline single-line copy of agent-card.json (whitespace stripped). Keep in sync with src/main/resources/agent-card.json
+agent.card.json={...}
+```
+
+Generate `agent.card.json` by JSON-stringifying the agent-card.json with no whitespace.
+
+### 5. Substitute config.yaml (planner + reasoner prompts)
+
+The template's prompts are tuned for **GetCreditScore** (single-tool, SSN-required). Generic them for the new agent:
+
+```yaml
+planner:
+  instruction: |-
+    Your job is to identify the tools needed to execute. Assess the user's query and return the steps and tools required for each step.
+
+    Allowed tools will be provided to you. Use only those tools. Do not invent tool names or parameters. Execute each tool only once.
+
+    The MCP server exposes the following skills: <comma-list of skill names from agent-card.json>.
+
+    If the user's intent matches one of the available skills, produce a one-step plan that calls the appropriate tool with the inputs the user provided. Omit optional inputs the user didn't provide. If a required input is missing, return an empty plan and let the reasoning step ask for it.
+
+    If the user's query does not match any available skill, return an empty plan.
+
+    Critical Rule:
+    Respond with RAW JSON ONLY. Do not add Markdown formatting, code fences, language tags, backticks, or any explanatory text. Your output must be a single valid JSON object.
+
+    Output schema:
+      plan: array of step objects { tool, inputs, step? }
+      multiTools: false (set true if a step depends on a previous tool's output)
+      final: true (set false to continue planning after this round)
+
+reasoning:
+  instruction: |-
+    Answer the request politely.
+    If Current Observation is empty, no tools have been executed yet. Execute each tool only once, and never suggest tools that are already present in Current Observation or last tools used.
+
+    Available tools come from `vars.tools.tools`. Call a tool only when the user's request matches its purpose AND all required inputs are present in their query. If a required input is missing, do not call the tool — instead ask the user for the missing input. If the user's request is not about any available tool, do not call any tool — answer from general knowledge or ask a clarifying question.
+```
+
+If the user opted for "above plus planner/reasoner instructions", use *their* text verbatim instead of the generic template above. Don't try to merge.
+
+### 6. Substitute agent.xml
+
+Open `src/main/mule/agent.xml` and update:
+
+- `<a2a:connection ... agentPath="/credit-scoring-agent" />` → `agentPath="/<agent-path>"`
+- All flow names containing `credit-scoring` or `creditScore` → kept generic. The template flow names (`A2AAgentFlow`, `set-and-initialise-vars-a2a-agent`, `create-plan`, `assess-and-execute`, `replan-tool-exec`) are not credit-specific and should stay as-is. Don't rename them.
+- The hardcoded SSN-redaction instruction inside the **final-reply** prompt template:
+  ```
+  Lead with the credit score returned by GetCreditScore. State the numeric score and, if present, the band. Do not invent numbers — only cite values that appear in the tool calls. Never disclose the applicant's full national ID or SSN; reference only the last 4 digits if at all.
+  ```
+  Replace with a generic version:
+  ```
+  Lead with the result returned by the tool call. State the values directly. Do not invent values — only cite what appears in the tool calls. Don't echo any sensitive identifiers (SSN, full account numbers, secrets) verbatim — reference only last-4 digits if at all.
+  ```
+
+Leave port numbers, listener configs, MCP/A2A/inference connector configs, scatter-gather, foreach, and DataWeave transforms untouched. They're tool/skill-agnostic.
+
+### 7. Rewrite README.md
+
+The template README is heavily tied to credit scoring (sample prompts, sequence diagrams labelled "credit score", etc.). Rather than surgically edit, **regenerate** the README from a smaller skeleton:
+
+```markdown
+# <Agent Display Name>
+
+A headless A2A (Agent-to-Agent) Mule application that <one-line description>. It receives an A2A `message/send` task, reasons about the user's intent with Gemini, calls a remote MCP server's tool(s), and returns a natural-language answer plus the structured tool result.
+
+## Skills
+
+| Skill | Inputs | Output |
+|---|---|---|
+| `<Skill_Name>` | <required + optional inputs> | <description of output> |
+
+## Architecture
+
+This agent uses the same plan-then-execute architecture as `a2a-credit-scoring-agent`. See that project's README for full mermaid diagrams. The flows in `agent.xml` are unchanged from that template — only the agent card, MCP URL, and prompts differ.
+
+## Configuration
+
+`src/main/resources/config.properties`:
+- `mcp.host.url` — upstream MCP server (no trailing `/mcp`)
+- `llm.api.key` — Gemini API key (currently `__REPLACE_ME__` — fill in before running)
+- `llm.model.name` — `gemini-2.5-flash`
+- `agent.url` — A2A self-loopback URL
+- `agent.card.json` — inline single-line agent card
+
+`src/main/resources/config.yaml` — planner + reasoner instruction prompts.
+
+## Running locally
+
+See template README for full instructions. Quick path:
+
+```bash
+JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home \
+  PATH=$JAVA_HOME/bin:$PATH \
+  mvn -q -o package -DskipTests
+cp target/<agent-name>-1.0.0-mule-application.jar ~/AnypointCodeBuilder/runtime/mule-enterprise-standalone-4.11.2/apps/
+```
+
+Test:
+```bash
+curl -X POST http://localhost:8081/<agent-path> \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"t1","method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"<sample prompt>"}]}}}'
+```
+
+## Production hardening
+
+Inherits all the caveats from `a2a-credit-scoring-agent` README (Tier 1: rotate key, secure-properties, auth on the endpoint, log redaction). Read that section before deploying anywhere real.
+```
+
+### 8. Validate
+
+```bash
+mcp__mulesoft__validate_project(projectPath="~/projects/active/<agent-name>")
+```
+
+If validation fails, surface the errors and **stop**. Don't try to "fix and retry" silently — the most common cause is a mismatch between the new agent name and a leftover reference inside `agent.xml` or `pom.xml`.
+
+### 9. Final report
+
+Tell the user:
+- Project path: `~/projects/active/<agent-name>/`
+- Mule runtime version used
+- Agent endpoint locally: `http://localhost:8081/<agent-path>`
+- A2A client wrapper: `http://localhost:7081/a2a-client`
+- Skills wired: list them
+- **Action items**:
+  - Replace `llm.api.key=__REPLACE_ME__` in `config.properties` with a real Gemini key
+  - Verify the MCP server is reachable from `mcp.host.url`
+  - Tune `config.yaml` planner/reasoner prompts as needed for the actual tool behavior
+- Next steps: run locally → smoke-test with sample A2A prompt → deploy to CH 2.0 via `/deploy-ch2`
+
+## Rules
+
+- **Latest Mule Runtime**, verified via MCP — never hard-code from training data.
+- **Java 17** in `mule-artifact.json`.
+- **CloudHub 2.0** deploy block in `pom.xml` — not CH 1.0 or RTF.
+- **Project under `~/projects/active/`**.
+- **Never write a real API key** into `config.properties` — use `__REPLACE_ME__` and warn the user.
+- **Never include `/mcp`** suffix in `mcp.host.url` — the connector appends it.
+- **Don't rename the template flow names** (`A2AAgentFlow`, `create-plan`, `assess-and-execute`, etc.) — they're generic and downstream tooling may reference them.
+- Keep `agent-card.json` and the inline `agent.card.json` in `config.properties` **in sync**.
+
+## What this skill does NOT do
+
+- Does **not** implement the MCP server. The user must already have an MCP server running with their tools — this skill only wires the agent to it.
+- Does **not** publish to Exchange. Run `/api-spec-publish` separately if you want the agent card in Exchange.
+- Does **not** deploy. Hand off to `/deploy-ch2` when ready.
+- Does **not** configure auth on the A2A endpoint. The scaffolded agent is open by default — see Tier-1 hardening in the credit-scoring README.
+
+## Example
+
+> Create a new A2A agent for loan approvals using my MCP server at https://example.com/mcp/loans
+
+1. Suggest `loan-approval-agent`, agent path `/loan-approval-agent`. Confirm.
+2. Ask for skills — user provides:
+   - `id: 1`, `name: Approve_Loan`, description, tags `["loan","approval"]`
+3. Verify latest Mule runtime via MCP.
+4. Show plan, get confirmation.
+5. Copy template → substitute name/skills/MCP URL → regenerate README.
+6. Validate, report path + action items.

--- a/claude-skills/new-a2a-agent/SKILL.md
+++ b/claude-skills/new-a2a-agent/SKILL.md
@@ -5,7 +5,25 @@ description: Scaffold a new A2A (Agent-to-Agent) Mule application by copying the
 
 # New A2A agent (scaffold from credit-scoring template)
 
-Creates a new Mule A2A agent by copying `~/projects/active/a2a-credit-scoring-agent/` and rewriting the parts that vary per agent. The template is a known-working **plan-then-execute** loop with Planner LLM + Reasoner LLM + MCP tool calling + A2A server/client.
+Creates a new Mule A2A agent by copying the `a2a-credit-scoring-agent` template and rewriting the parts that vary per agent. The template is a known-working **plan-then-execute** loop with Planner LLM + Reasoner LLM + MCP tool calling + A2A server/client.
+
+## Resolving the template source
+
+The template lives in the public repo [MuleSoft-AI-Chain-Project/example-mule-apps](https://github.com/MuleSoft-AI-Chain-Project/example-mule-apps) under `a2a-credit-scoring-agent/`. The skill is portable across developers — resolve the source path in this order:
+
+1. **`A2A_TEMPLATE_DIR` env var** — if set, use it directly. Lets users override.
+2. **Local clone** — if `~/projects/active/a2a-credit-scoring-agent/` exists, use it.
+3. **Sparse-clone from GitHub** — last resort:
+   ```bash
+   TPL=$(mktemp -d)
+   git clone --depth=1 --filter=blob:none --sparse \
+     https://github.com/MuleSoft-AI-Chain-Project/example-mule-apps.git "$TPL"
+   git -C "$TPL" sparse-checkout set a2a-credit-scoring-agent
+   TEMPLATE_SRC="$TPL/a2a-credit-scoring-agent"
+   ```
+   Tell the user the clone is temporary and will be discarded after scaffolding.
+
+Use `$TEMPLATE_SRC` (resolved above) wherever the steps below say "the template".
 
 ## Inputs needed
 
@@ -41,10 +59,12 @@ Get explicit confirmation. **Don't skip this.**
 ### 2. Copy the template
 
 ```bash
-cp -R ~/projects/active/a2a-credit-scoring-agent ~/projects/active/<agent-name>
+cp -R "$TEMPLATE_SRC" ~/projects/active/<agent-name>
 cd ~/projects/active/<agent-name>
-rm -rf target .mule .vscode
+rm -rf target .mule .vscode .git
 ```
+
+(`.git` removal only matters if `$TEMPLATE_SRC` was a fresh clone — otherwise the directory won't have one.)
 
 Then delete files that shouldn't carry over:
 - `target/`, `.mule/`, `.vscode/launch.json` if present


### PR DESCRIPTION
## Summary
- Adds a `claude-skills/` directory at the repo root with a brief README explaining what Claude Code skills are and how to install them.
- Adds **`new-a2a-agent`** — scaffolds a new A2A Mule agent by copying the `a2a-credit-scoring-agent` template (in this repo) and substituting agent name, skills, MCP URL, and planner/reasoner prompts. Resolves the template via `\$A2A_TEMPLATE_DIR` env var → local clone → sparse-clone from this repo.
- Adds **`deploy-ch2`** — wraps `mcp__mulesoft__deploy_mule_application` with pre-flight checks (package, POM target, secret scan, runtime currency, name collision) and a confirmation checkpoint before deploying.

## Why here
This repo already hosts A2A example apps and Mule deployments. Co-locating the scaffolding + deployment skills makes them discoverable for anyone using these examples as starting points. Both skills have been genericized — no machine-specific paths.

## Test plan
- [ ] `cp -R claude-skills/new-a2a-agent claude-skills/deploy-ch2 ~/.claude/skills/`, restart Claude Code, confirm both `/new-a2a-agent` and `/deploy-ch2` appear in the skill list
- [ ] Run `/new-a2a-agent` against a sample MCP server and verify the generated project validates via `mcp__mulesoft__validate_project`
- [ ] Run `/deploy-ch2` against a sample Mule project and verify the pre-flight + confirmation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)